### PR TITLE
Fix UI bug, update docs, and add basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ cp .env.example .env.local
 4. Preencha as variáveis de ambiente no arquivo `.env.local`:
 - `NEXT_PUBLIC_SUPABASE_URL`: URL do seu projeto Supabase
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`: Chave anônima do Supabase
+- `NEXT_PUBLIC_AMPLITUDE_API_KEY`: Chave do Amplitude (opcional)
 
 ## Desenvolvimento
 
@@ -129,14 +130,14 @@ src/
 │   ├── create-bet/       # Página de criação
 │   └── page.tsx          # Home page
 ├── lib/                   # Utilitários
-│   └── storage.ts        # Armazenamento em memória
+│   └── storage.ts        # Integração com Supabase
 └── types/                # Definições de tipos
     └── bet.ts           # Tipos de apostas
 ```
 
 ## Notas
 
-- Este é um MVP e usa armazenamento em memória. Em produção, recomenda-se usar um banco de dados.
+- Este é um MVP e utiliza Supabase para persistência. Em produção, recomenda-se revisar a configuração do banco de dados.
 - Não há autenticação ou pagamentos reais.
 - O criador da aposta é responsável por coletar e distribuir os valores.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts']
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.17.9",
@@ -28,6 +29,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.0"
   }
 }

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -41,8 +41,10 @@ export default function CreateBetPage() {
   }
 
   const addOption = () => {
-    setOptions([...options, ''])
-    setFormInteractions(prev => prev + 1)
+    if (options.length < 10) {
+      setOptions([...options, ''])
+      setFormInteractions(prev => prev + 1)
+    }
   }
 
   const removeOption = (index: number) => {
@@ -274,10 +276,14 @@ export default function CreateBetPage() {
               <button
                 type="button"
                 onClick={addOption}
-                className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+                disabled={options.length >= 10}
+                className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors disabled:opacity-50"
               >
                 + Adicionar Opção
               </button>
+              {options.length >= 10 && (
+                <span className="text-red-300 text-sm">Limite de 10 opções atingido</span>
+              )}
             </div>
 
             <div className="space-y-4">

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -44,9 +44,9 @@ export function ShareButton({ url, title, onClick, onSuccess }: ShareButtonProps
         viewBox="0 0 20 20"
         fill="currentColor"
       >
-        <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47C13.456 7.68 14.19 8 15 8z" />
+        <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47A3 3 0 0015 8z" />
       </svg>
       {copied ? 'Link copiado!' : 'Compartilhar'}
     </button>
   )
-} 
+}

--- a/src/lib/__tests__/storage.test.ts
+++ b/src/lib/__tests__/storage.test.ts
@@ -1,0 +1,46 @@
+import { getAllBets } from '../storage'
+
+const mockFrom = jest.fn()
+
+jest.mock('../supabase', () => ({
+  supabase: { from: mockFrom }
+}))
+
+describe('getAllBets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('filters public bets when no email is provided', async () => {
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      order: jest.fn().mockResolvedValue({ data: [], error: null })
+    }
+    mockFrom.mockReturnValueOnce(query)
+
+    await getAllBets()
+
+    expect(mockFrom).toHaveBeenCalledWith('apostas')
+    expect(query.select).toHaveBeenCalledWith('*')
+    expect(query.eq).toHaveBeenCalledWith('visibilidade', 'public')
+    expect(query.order).toHaveBeenCalledWith('created_at', { ascending: false })
+  })
+
+  it('includes private bets for creator when email is provided', async () => {
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      order: jest.fn().mockResolvedValue({ data: [], error: null })
+    }
+    mockFrom.mockReturnValueOnce(query)
+
+    await getAllBets('user@example.com')
+
+    expect(query.or).toHaveBeenCalledWith(
+      'and(visibilidade.eq.public),and(visibilidade.eq.private,email_criador.eq.user@example.com)'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- fix malformed share icon path
- limit bet options to 10 and show warning
- clarify environment variables and storage in README
- add Jest configuration and first storage tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403a6d6ac08327b11a01ba952e349b