### PR TITLE
Improve Google sign-in button and auto-fill voter info

### DIFF
--- a/src/app/bet/[id]/page.tsx
+++ b/src/app/bet/[id]/page.tsx
@@ -24,6 +24,12 @@ export default function BetPage() {
   const [formInteractions, setFormInteractions] = useState(0)
 
   useEffect(() => {
+    if (user) {
+      setVoterName(user.email)
+    }
+  }, [user])
+
+  useEffect(() => {
     const fetchData = async () => {
       if (!params.id) return
 
@@ -108,7 +114,7 @@ export default function BetPage() {
       });
       
       // Clear form
-      setVoterName('')
+      setVoterName(user ? user.email : '')
       setSelectedOption('')
       setFormInteractions(0)
       
@@ -347,11 +353,14 @@ export default function BetPage() {
                 <input
                   type="text"
                   value={voterName}
+                  disabled={!!user}
                   onChange={(e) => {
-                    setVoterName(e.target.value)
-                    trackFieldChange('voterName', e.target.value)
+                    if (!user) {
+                      setVoterName(e.target.value)
+                      trackFieldChange('voterName', e.target.value)
+                    }
                   }}
-                  className="w-full px-3 py-2 bg-white/10 border border-purple-500/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-white placeholder:text-purple-300"
+                  className="w-full px-3 py-2 bg-white/10 border border-purple-500/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-white placeholder:text-purple-300 disabled:opacity-70"
                   placeholder="Como você quer ser identificado"
                   required
                 />

--- a/src/components/auth-button.tsx
+++ b/src/components/auth-button.tsx
@@ -53,9 +53,16 @@ export function AuthButton() {
   return (
     <button
       onClick={handleSignIn}
-      className="bg-blue-600 text-white px-4 py-2 rounded-md font-medium hover:bg-blue-700 transition-colors"
+      className="flex items-center gap-2 bg-white text-gray-700 border border-gray-300 px-4 py-2 rounded-md font-medium shadow hover:bg-gray-100 transition-colors"
     >
+      <svg className="w-5 h-5" viewBox="0 0 488 512" aria-hidden="true" focusable="false">
+        <path d="M488 261.8c0-17-1.4-33.7-4-49.6H249v94h134c-5.8 31.3-22.7 57.8-48.1 75.5v62.7h77.9c45.7-42 71.9-103.9 71.9-182.6z" fill="#4285F4" />
+        <path d="M249 512c65.7 0 120.9-21.7 161.2-59.3l-77.9-62.7c-21.7 14.5-49.6 23.2-83.3 23.2-63.9 0-118-43.1-137.3-101.3H31.1v63.5C71.3 464 154.9 512 249 512z" fill="#34A853" />
+        <path d="M111.7 311.9c-6.9-20.7-10.8-42.8-10.8-65.9s3.9-45.2 10.8-65.9V116.6H31.1A249.6 249.6 0 000 245.9c0 39.6 9.4 77.1 26.1 112.1l85.6-46.1z" fill="#FBBC05" />
+        <path d="M249 97.5c35.6 0 67.4 12.3 92.5 36.3l69.3-69.3C365.9 24.5 310.7 0 249 0 154.9 0 71.3 48 31.1 116.6l85.6 65.9c19.3-58.2 73.4-101.3 137.3-101.3z" fill="#EA4335" />
+        <path fill="none" d="M0 0h488v512H0z" />
+      </svg>
       Entrar com Google
     </button>
   )
-} 
+}


### PR DESCRIPTION
## Summary
- style Google login button with official colors and add icon
- pre-fill voter name with signed-in email on bet pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2356f3b48327891645ec65078cdb