### PR TITLE
Implement guest betting option

### DIFF
--- a/src/app/api/bets/route.ts
+++ b/src/app/api/bets/route.ts
@@ -38,6 +38,7 @@ export async function POST(request: Request) {
       nome_criador: data.nome_criador,
       email_criador: data.email_criador,
       visibilidade: data.visibilidade || 'public',
+      permitir_sem_login: data.permitir_sem_login ?? false,
     }
 
     const createdBet = await addBet(newBet)

--- a/src/app/bet/[id]/page.tsx
+++ b/src/app/bet/[id]/page.tsx
@@ -375,7 +375,7 @@ export default function BetPage() {
             </div>
           )}
 
-          {!isCreator && !bet.resultado_final && (
+          {!isCreator && !bet.resultado_final && (bet.permitir_sem_login || user) && (
             <form onSubmit={handleVote} className="space-y-4">
               <div>
                 <label className="block text-sm font-medium mb-2">Seu Nome *</label>
@@ -423,6 +423,12 @@ export default function BetPage() {
                 {isLoading ? 'Registrando...' : 'Registrar Aposta'}
               </button>
             </form>
+          )}
+
+          {!isCreator && !bet.resultado_final && !bet.permitir_sem_login && !user && (
+            <p className="mt-4 text-center text-purple-200">
+              Faça login para registrar sua aposta
+            </p>
           )}
 
           {bet.resultado_final && (

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -17,6 +17,7 @@ export default function CreateBetPage() {
   const [endDate, setEndDate] = useState('')
   const [options, setOptions] = useState<string[]>(['', ''])
   const [visibility, setVisibility] = useState<'public' | 'private'>('public')
+  const [allowGuest, setAllowGuest] = useState(true)
   const [error, setError] = useState('')
   const [formInteractions, setFormInteractions] = useState(0)
 
@@ -68,6 +69,7 @@ export default function CreateBetPage() {
         endDate,
         optionsCount: options.length,
         visibility,
+        allowGuest,
         formInteractions
       },
       timestamp: new Date().toISOString()
@@ -90,6 +92,7 @@ export default function CreateBetPage() {
         data_encerramento: endDate,
         opcoes: options.filter(opt => opt.trim() !== ''),
         visibilidade: visibility,
+        permitir_sem_login: allowGuest,
         email_criador: user.email,
       }
 
@@ -101,6 +104,7 @@ export default function CreateBetPage() {
         betId: newBet.id,
         betTitle: newBet.titulo,
         betType: newBet.visibilidade,
+        allowGuest: newBet.permitir_sem_login,
         optionsCount: newBet.opcoes.length,
         betValue: newBet.valor_aposta,
         endDate: newBet.data_encerramento,
@@ -125,6 +129,7 @@ export default function CreateBetPage() {
           endDate,
           optionsCount: options.length,
           visibility,
+          allowGuest,
           formInteractions
         },
         timestamp: new Date().toISOString()
@@ -259,11 +264,45 @@ export default function CreateBetPage() {
                     setVisibility(e.target.value as 'public' | 'private')
                     trackFieldChange('visibility', e.target.value)
                   }}
-                  className="w-full px-3 py-2 bg-white/10 border border-purple-500/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-white"
+                  className="w-full px-3 py-2 bg-white/10 border border-purple-500/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-gray-900"
                 >
                   <option value="public">Pública</option>
                   <option value="private">Privada</option>
                 </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-2">Permitir apostas sem login?</label>
+                <div className="flex gap-4">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="allowGuest"
+                      value="true"
+                      checked={allowGuest}
+                      onChange={() => {
+                        setAllowGuest(true)
+                        trackFieldChange('allowGuest', 'true')
+                      }}
+                      className="form-radio text-purple-500"
+                    />
+                    <span className="text-gray-200">Sim</span>
+                  </label>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="allowGuest"
+                      value="false"
+                      checked={!allowGuest}
+                      onChange={() => {
+                        setAllowGuest(false)
+                        trackFieldChange('allowGuest', 'false')
+                      }}
+                      className="form-radio text-purple-500"
+                    />
+                    <span className="text-gray-200">Não</span>
+                  </label>
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,26 @@ export default function Home() {
       <div className="max-w-2xl mx-auto">
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-3xl font-bold">Apostas</h1>
-          <AuthButton />
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => {
+                track(ANALYTICS_EVENTS.BET_CREATION_START, {
+                  user: user ? getUserProperties(user) : null,
+                  timestamp: new Date().toISOString()
+                })
+                router.push('/create')
+              }}
+              className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+                user
+                  ? 'bg-purple-600 text-white hover:bg-purple-700'
+                  : 'bg-gray-600 text-gray-300 cursor-not-allowed'
+              }`}
+              disabled={!user}
+            >
+              {user ? 'Criar Nova Aposta' : 'Logue para criar'}
+            </button>
+            <AuthButton />
+          </div>
         </div>
 
         {error && (
@@ -128,25 +147,6 @@ export default function Home() {
           })}
         </div>
 
-        <div className="mt-8 text-center">
-          <button
-            onClick={() => {
-              track(ANALYTICS_EVENTS.BET_CREATION_START, {
-                user: user ? getUserProperties(user) : null,
-                timestamp: new Date().toISOString()
-              });
-              router.push('/create')
-            }}
-            className={`px-6 py-3 rounded-lg font-medium transition-colors ${
-              user
-                ? 'bg-purple-600 text-white hover:bg-purple-700'
-                : 'bg-gray-600 text-gray-300 cursor-not-allowed'
-            }`}
-            disabled={!user}
-          >
-            {user ? 'Criar Nova Aposta' : 'Logue para criar uma aposta'}
-          </button>
-        </div>
       </div>
     </main>
   )

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -26,10 +26,13 @@ export const addBet = async (bet: Omit<Bet, 'id' | 'created_at'>) => {
   
   const { data, error } = await supabase
     .from('apostas')
-    .insert([{
-      ...bet,
-      opcoes: bet.opcoes // Ensure it's passed as a proper array
-    }])
+    .insert([
+      {
+        ...bet,
+        opcoes: bet.opcoes, // Ensure it's passed as a proper array
+        permitir_sem_login: bet.permitir_sem_login
+      }
+    ])
     .select()
     .single()
 

--- a/src/types/bet.ts
+++ b/src/types/bet.ts
@@ -7,6 +7,10 @@ export interface Bet {
   data_encerramento: string
   nome_criador: string
   email_criador: string
+  /**
+   * Define se esta aposta permite participantes não autenticados.
+   */
+  permitir_sem_login: boolean
   resultado_final?: string
   visibilidade: 'public' | 'private'
   created_at: string


### PR DESCRIPTION
## Summary
- allow users to toggle guest betting during bet creation
- fix visibility select colors
- display login requirement message if guest betting is disabled
- move "Criar Nova Aposta" button to header
- extend database types and API to store guest betting flag

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2f3aeb308327a0a409699639bca3