### PR TITLE
Fix logout button layout on mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,9 +65,9 @@ export default function Home() {
   return (
     <main className="min-h-screen p-4 md:p-8 bg-gradient-to-b from-purple-900 to-purple-800 text-white">
       <div className="max-w-2xl mx-auto">
-        <div className="flex items-center justify-between mb-8">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
           <h1 className="text-3xl font-bold">Apostas</h1>
-          <div className="flex items-center gap-4">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-4">
             <button
               onClick={() => {
                 track(ANALYTICS_EVENTS.BET_CREATION_START, {

--- a/src/components/auth-button.tsx
+++ b/src/components/auth-button.tsx
@@ -36,8 +36,8 @@ export function AuthButton() {
 
   if (user) {
     return (
-      <div className="flex items-center gap-4">
-        <span className="text-sm text-white">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-4">
+        <span className="text-sm text-white break-all">
           Olá, {user.email}
         </span>
         <button


### PR DESCRIPTION
## Summary
- make main page header responsive for small screens
- stack email and logout button vertically on mobile

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871372441408327b17c8c6654d2d60e